### PR TITLE
Mark the dist deprecated in the meta.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -49,3 +49,4 @@ stopwords = foo
 [ConfirmRelease]
 [UploadToCPAN]
 [CopyFilesFromBuild]
+[Deprecated]


### PR DESCRIPTION
Hi @ology 

Please review the PR.
http://neilb.org/2015/01/17/deprecated-metadata.html

Many Thanks.
Best Regards,
Mohammad S Anwar